### PR TITLE
Timeline events

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -54,6 +54,12 @@ return [
                     'mautic.helper.integration'
                 ],
             ],
+            'mautic.recommender.lead.timeline.subscriber'  => [
+                'class'     => MauticPlugin\MauticRecommenderBundle\EventListener\LeadSubscriber::class,
+                'arguments' => [
+                    'mautic.helper.integration'
+                ],
+            ],
             'mautic.recommender.emailbundle.subscriber' => [
                 'class'     => MauticPlugin\MauticRecommenderBundle\EventListener\EmailSubscriber::class,
                 'arguments' => [

--- a/Entity/EventLog.php
+++ b/Entity/EventLog.php
@@ -58,7 +58,7 @@ class EventLog
     {
         $builder = new ClassMetadataBuilder($metadata);
         $builder->setTable('recommender_event_log')
-            ->setCustomRepositoryClass(ItemRepository::class)
+            ->setCustomRepositoryClass(EventLogRepository::class)
             ->addIndex(['item_id'], 'item_id_index')
             ->addIndex(['event_id'], 'event_id_index')
             ->addId()

--- a/Entity/EventLogRepository.php
+++ b/Entity/EventLogRepository.php
@@ -76,8 +76,8 @@ class EventLogRepository extends CommonRepository
             $qb->leftJoin('ri', 'recommender_item_property_value', 'ripv', 'ri.id = ripv.item_id');
             $qb->andWhere(
                 $qb->expr()->orX(
-                    $qb->expr()->like('re.properties', $qb->expr()->literal('%'.$options['search'].'%')),
-                    $qb->expr()->like('ri.properties', $qb->expr()->literal('%'.$options['search'].'%'))
+                    $qb->expr()->like('re.name', $qb->expr()->literal('%'.$options['search'].'%')),
+                    $qb->expr()->like('ripv.value', $qb->expr()->literal('%'.$options['search'].'%'))
                 )
             );
             $qb->groupBy($alias.'.id');

--- a/Entity/EventLogRepository.php
+++ b/Entity/EventLogRepository.php
@@ -16,6 +16,7 @@ use Mautic\CoreBundle\Entity\CommonRepository;
 use MauticPlugin\MauticRecommenderBundle\Helper\SqlQuery;
 
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\TimelineTrait;
 
 /**
  * Class EventLogRepository
@@ -23,6 +24,7 @@ use Mautic\LeadBundle\Entity\Lead;
  */
 class EventLogRepository extends CommonRepository
 {
+    use TimelineTrait;
 
     /**
      * @return string

--- a/EventListener/LeadSubscriber.php
+++ b/EventListener/LeadSubscriber.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace MauticPlugin\MauticRecommenderBundle\EventListener;
+
+use Mautic\CoreBundle\EventListener\CommonSubscriber;
+use Mautic\CoreBundle\Factory\ModelFactory;
+use Mautic\CoreBundle\Translation\Translator;
+use Mautic\LeadBundle\Event\LeadTimelineEvent;
+use Mautic\LeadBundle\LeadEvents;
+
+use Mautic\PluginBundle\Helper\IntegrationHelper;
+
+/**
+ * Class LeadSubscriber.
+ */
+class LeadSubscriber extends CommonSubscriber
+{
+     /**
+     * @var integrationHelper
+     */
+    protected $integrationHelper;
+
+    /**
+     * LeadSubscriber constructor.
+     *
+     * @param FormModel $formModel
+     * @param PageModel $pageModel
+     */
+    public function __construct(IntegrationHelper $integrationHelper)
+    {        
+        $this->integrationHelper      = $integrationHelper;           
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            LeadEvents::TIMELINE_ON_GENERATE => ['onTimelineGenerate', 0],
+            LeadEvents::LEAD_POST_MERGE      => ['onLeadMerge', 0],
+        ];
+    }
+
+    /**
+     * Compile events for the lead timeline.
+     *
+     * @param LeadTimelineEvent $event
+     */
+    public function onTimelineGenerate(LeadTimelineEvent $event)
+    {
+
+        $integration = $this->integrationHelper->getIntegrationObject('Recommender');
+        if (!$integration){
+            return;
+        }
+        $integrationSettings = $integration->getIntegrationSettings();
+        if (!$integration || $integrationSettings->getIsPublished() === false) {
+            return;
+        }
+
+        // Set available event types
+        $eventTypeKey  = 'recommender.event';
+        $eventTypeName = $this->translator->trans('mautic.plugin.recommender.event.timeline_event');
+        $event->addEventType($eventTypeKey, $eventTypeName);        
+
+        if (!$event->isApplicable($eventTypeKey)) {
+            return;
+        }
+
+        /** @var \Mautic\FormBundle\Entity\SubmissionRepository $submissionRepository */
+        $eventLogRepository = $this->em->getRepository('MauticRecommenderBundle:EventLog');
+        $rows               = $eventLogRepository->getTimeLineEvents($event->getLead(), $event->getQueryOptions());
+
+        // Add total to counter
+        $event->addToCounter($eventTypeKey, $rows);
+
+        if (!$event->isEngagementCount()) {
+            // Add the submissions to the event array
+            foreach ($rows['results'] as $row) {
+                $eventLogEntity   = $eventLogRepository->getEntity($row['id']);
+                
+                $event->addEvent(
+                    [
+                        'event'      => $eventTypeKey,
+                        'eventId'    => $eventTypeKey.$row['id'],
+                        'eventLabel' => $this->getLabel($eventLogEntity),
+                        'eventType' => $eventTypeName,
+                        'timestamp' => $row['date_added'],                   
+                        'icon'            => 'fa-shopping-bag',
+                        'contactId'       => $row['lead_id'],
+                    ]
+                );
+            }
+        }
+    }
+
+    private function getLabel($eventLogEntity){
+        return $this->translator->trans(
+            'mautic.plugin.recommender.event.timeline_event.label',
+            [
+                '%event_name%' => $eventLogEntity->getEvent() ? $eventLogEntity->getEvent()->getName() : 'deleted',
+                '%item_id%' => $eventLogEntity->getItem() ? $eventLogEntity->getItem()->getId() : 'deleted'
+            ]
+        );
+    }
+
+    /**
+     * @param LeadMergeEvent $event
+     */
+    public function onLeadMerge(LeadMergeEvent $event)
+    {
+        //$this->em->getRepository('MauticFormBundle:Submission')->updateLead($event->getLoser()->getId(), $event->getVictor()->getId());
+    }
+}

--- a/Translations/en_US/messages.ini
+++ b/Translations/en_US/messages.ini
@@ -57,7 +57,7 @@ mautic.plugin.recommender.templates="Templates"
 mautic.plugin.recommender.template="Template"
 mautic.plugin.recommender.event="Events"
 mautic.plugin.recommender.event.timeline_event="Recommender event logged"
-mautic.plugin.recommender.event.timeline_event.label="Contact performaed a '%event_name%' event on item '%item_id%'"
+mautic.plugin.recommender.event.timeline_event.label="'%event_name%' event logged for contact on item '%item_id%'"
 
 mautic.plugin.recommender.form.event.name="Event Name"
 mautic.plugin.recommender.form.event.weight="Weight"

--- a/Translations/en_US/messages.ini
+++ b/Translations/en_US/messages.ini
@@ -56,6 +56,8 @@ mautic.plugin.recommenders="Recommenders"
 mautic.plugin.recommender.templates="Templates"
 mautic.plugin.recommender.template="Template"
 mautic.plugin.recommender.event="Events"
+mautic.plugin.recommender.event.timeline_event="Recommender event logged"
+mautic.plugin.recommender.event.timeline_event.label="Contact performaed a '%event_name%' event on item '%item_id%'"
 
 mautic.plugin.recommender.form.event.name="Event Name"
 mautic.plugin.recommender.form.event.weight="Weight"


### PR DESCRIPTION
### Adding Timeline events from `recommender_event_log` table
- Events tracked for a contact are now displayed in the contact's timeline
- Event name and item_id is displayed in a row

Further details regarding the item can be added in a dropdown later
If there were an `Item management interface` linking the product there would be possible


Also I fixed a possible bug in `Entity/EventLog.php` :
> ->setCustomRepositoryClass(ItemRepository::class)
to:
> ->setCustomRepositoryClass(EventLogRepository::class)